### PR TITLE
Remove Lizard Bot from resource list

### DIFF
--- a/src/js/constants/MenuLists.ts
+++ b/src/js/constants/MenuLists.ts
@@ -326,10 +326,6 @@ export const RES_APPS_LIST = {
         desc: "An excellent SFV & SF6 frame data Discord bot",
         url: "https://github.com/ellipses/Yaksha",
       },
-      "Lizard Bot": {
-        desc: "A super useful Discord bot for running tournaments",
-        url: "https://github.com/lizardman301/Lizard-bot-rsf",
-      },
     },
   },
   "SFV PC Stuff": {


### PR DESCRIPTION
Lizardman301 and I deprecated [Lizard Bot](https://github.com/lizardman301/Lizard-bot-rsf) March 10th, 2024. I saw that it was still referenced here and figured we should clean it up